### PR TITLE
Suppress warning C4396 for VS in limited_value.hpp

### DIFF
--- a/include/oglplus/limited_value.hpp
+++ b/include/oglplus/limited_value.hpp
@@ -17,6 +17,11 @@
 #include <oglplus/error.hpp>
 #include <cassert>
 
+#ifdef _MSC_VER
+#pragma warning( push )
+#pragma warning( disable : 4396 )
+#endif // _MSC_VER
+
 namespace oglplus {
 
 template <GLenum Query>
@@ -148,5 +153,9 @@ public: \
 };
 
 } // namespace oglplus
+
+#ifdef _MSC_VER
+#pragma warning( pop )
+#endif // _MSC_VER
 
 #endif // include guard


### PR DESCRIPTION
Suppressed warning C4396 for Visual Studio since this file generates 30-40 warnings every time it is included.
