### PR TITLE
ill format of font resource file error message

### DIFF
--- a/implement/oglplus/opt/resources.ipp
+++ b/implement/oglplus/opt/resources.ipp
@@ -75,7 +75,6 @@ ResourceFile::ResourceFile(
 			category +
 			aux::FilesysPathSep() +
 			name +
-			aux::FilesysPathSep()+
 			ext +
 			std::string("'")
 		);


### PR DESCRIPTION
I ran the standalone example 004_any_text_rendering and I get this error message which I consider ill-formated.

```
./004_any_text_rendering
Started
Error: Failed to open resource file 'fonts/FreeSans/.ttf'
```
