### PR TITLE
Updated GLM interop

### DIFF
--- a/include/oglplus/interop/glm.hpp
+++ b/include/oglplus/interop/glm.hpp
@@ -23,11 +23,11 @@ namespace aux {
 
 #define OGLPLUS_HLPR_IMPL_GLM_VECTOR_ADAPTER(DIM) \
 template <class T> \
-struct ThirdPartyVectorBase<glm::detail::tvec##DIM<T> > \
+struct ThirdPartyVectorBase<glm::detail::tvec##DIM<T, glm::highp> > \
 { \
 	typedef T Type; \
 	typedef std::integral_constant<std::size_t, DIM> N; \
-	static const T* Data(glm::detail::tvec##DIM<T> const & v)\
+	static const T* Data(glm::detail::tvec##DIM<T, glm::highp> const & v)\
 	{ \
 		return glm::value_ptr(v); \
 	} \
@@ -41,13 +41,13 @@ OGLPLUS_HLPR_IMPL_GLM_VECTOR_ADAPTER(4)
 
 #define OGLPLUS_HLPR_IMPL_GLM_MATRIX_ADAPTER(ROWS, COLS) \
 template <class T> \
-struct ThirdPartyMatrixBase<glm::detail::tmat##COLS##x##ROWS<T> > \
+struct ThirdPartyMatrixBase<glm::detail::tmat##COLS##x##ROWS<T, glm::highp> > \
 { \
 	typedef T Type; \
 	typedef std::integral_constant<std::size_t, ROWS> Rows; \
 	typedef std::integral_constant<std::size_t, COLS> Cols; \
 	typedef std::integral_constant<bool, false> IsRowMajor; \
-	static const T* Data(glm::detail::tmat##COLS##x##ROWS<T> const & m)\
+	static const T* Data(glm::detail::tmat##COLS##x##ROWS<T, glm::highp> const & m)\
 	{ \
 		return glm::value_ptr(m); \
 	} \


### PR DESCRIPTION
oglplus with the latest version of GLM did not compile. 
It would appear that GLM started requiring a "precision type" in it's template signature.
I don't know how "accurate" setting the "precision type" to "glm::highp" is, but at the very least everything compiles.
