### PR TITLE
Do not check for errors in Draw* functions if OGLPLUS_LOW_PROFILE

### DIFF
--- a/include/oglplus/context/drawing.hpp
+++ b/include/oglplus/context/drawing.hpp
@@ -44,7 +44,7 @@ public:
 	)
 	{
 		OGLPLUS_GLFUNC(DrawArrays)(GLenum(primitive), first, count);
-		OGLPLUS_CHECK(
+		OGLPLUS_VERIFY(
 			DrawArrays,
 			Error,
 			EnumParam(primitive)
@@ -75,7 +75,7 @@ public:
 			inst_count,
 			base_instance
 		);
-		OGLPLUS_CHECK(
+		OGLPLUS_VERIFY(
 			DrawArraysInstancedBaseInstance,
 			Error,
 			EnumParam(primitive)
@@ -105,7 +105,7 @@ public:
 			count,
 			inst_count
 		);
-		OGLPLUS_CHECK(
+		OGLPLUS_VERIFY(
 			DrawArraysInstanced,
 			Error,
 			EnumParam(primitive)
@@ -131,7 +131,7 @@ public:
 			GLenum(primitive),
 			indirect
 		);
-		OGLPLUS_CHECK(
+		OGLPLUS_VERIFY(
 			DrawArraysIndirect,
 			Error,
 			EnumParam(primitive)
@@ -162,7 +162,7 @@ public:
 			const_cast<GLsizei*>(count), // remove when GLEW fixed
 			primcount
 		);
-		OGLPLUS_CHECK(
+		OGLPLUS_VERIFY(
 			MultiDrawArrays,
 			Error,
 			EnumParam(primitive)
@@ -192,7 +192,7 @@ public:
 			draw_count,
 			stride
 		);
-		OGLPLUS_CHECK(
+		OGLPLUS_VERIFY(
 			MultiDrawArraysIndirect,
 			Error,
 			EnumParam(primitive)
@@ -219,7 +219,7 @@ public:
 			GLenum(data_type),
 			nullptr
 		);
-		OGLPLUS_CHECK(
+		OGLPLUS_VERIFY(
 			DrawElements,
 			Error,
 			EnumParam(primitive)
@@ -247,7 +247,7 @@ public:
 			GLenum(GetDataType<T>()),
 			indices
 		);
-		OGLPLUS_CHECK(
+		OGLPLUS_VERIFY(
 			DrawElements,
 			Error,
 			EnumParam(primitive)
@@ -275,7 +275,7 @@ public:
 			nullptr,
 			instance_count
 		);
-		OGLPLUS_CHECK(
+		OGLPLUS_VERIFY(
 			DrawElementsInstanced,
 			Error,
 			EnumParam(primitive)
@@ -305,7 +305,7 @@ public:
 			indices,
 			instance_count
 		);
-		OGLPLUS_CHECK(
+		OGLPLUS_VERIFY(
 			DrawElementsInstanced,
 			Error,
 			EnumParam(primitive)
@@ -337,7 +337,7 @@ public:
 			inst_count,
 			base_instance
 		);
-		OGLPLUS_CHECK(
+		OGLPLUS_VERIFY(
 			DrawElementsInstancedBaseInstance,
 			Error,
 			EnumParam(primitive)
@@ -370,7 +370,7 @@ public:
 			inst_count,
 			base_instance
 		);
-		OGLPLUS_CHECK(
+		OGLPLUS_VERIFY(
 			DrawElementsInstancedBaseInstance,
 			Error,
 			EnumParam(primitive)
@@ -400,7 +400,7 @@ public:
 			nullptr,
 			draw_count
 		);
-		OGLPLUS_CHECK(
+		OGLPLUS_VERIFY(
 			MultiDrawElements,
 			Error,
 			EnumParam(primitive)
@@ -430,7 +430,7 @@ public:
 			indices,
 			draw_count
 		);
-		OGLPLUS_CHECK(
+		OGLPLUS_VERIFY(
 			MultiDrawElements,
 			Error,
 			EnumParam(primitive)
@@ -461,7 +461,7 @@ public:
 			GLenum(data_type),
 			nullptr
 		);
-		OGLPLUS_CHECK(
+		OGLPLUS_VERIFY(
 			DrawRangeElements,
 			Error,
 			EnumParam(primitive)
@@ -493,7 +493,7 @@ public:
 			GLenum(GetDataType<T>()),
 			indices
 		);
-		OGLPLUS_CHECK(
+		OGLPLUS_VERIFY(
 			DrawRangeElements,
 			Error,
 			EnumParam(primitive)
@@ -520,7 +520,7 @@ public:
 			GLenum(data_type),
 			indirect
 		);
-		OGLPLUS_CHECK(
+		OGLPLUS_VERIFY(
 			DrawElementsIndirect,
 			Error,
 			EnumParam(primitive)
@@ -552,7 +552,7 @@ public:
 			draw_count,
 			stride
 		);
-		OGLPLUS_CHECK(
+		OGLPLUS_VERIFY(
 			MultiDrawElementsIndirect,
 			Error,
 			EnumParam(primitive)
@@ -583,7 +583,7 @@ public:
 			nullptr,
 			base_vertex
 		);
-		OGLPLUS_CHECK(
+		OGLPLUS_VERIFY(
 			DrawElementsBaseVertex,
 			Error,
 			EnumParam(primitive)
@@ -614,7 +614,7 @@ public:
 			indices,
 			base_vertex
 		);
-		OGLPLUS_CHECK(
+		OGLPLUS_VERIFY(
 			DrawElementsBaseVertex,
 			Error,
 			EnumParam(primitive)
@@ -647,7 +647,7 @@ public:
 			nullptr,
 			base_vertex
 		);
-		OGLPLUS_CHECK(
+		OGLPLUS_VERIFY(
 			DrawRangeElementsBaseVertex,
 			Error,
 			EnumParam(primitive)
@@ -682,7 +682,7 @@ public:
 			indices,
 			base_vertex
 		);
-		OGLPLUS_CHECK(
+		OGLPLUS_VERIFY(
 			DrawRangeElementsBaseVertex,
 			Error,
 			EnumParam(primitive)
@@ -713,7 +713,7 @@ public:
 			inst_count,
 			base_vertex
 		);
-		OGLPLUS_CHECK(
+		OGLPLUS_VERIFY(
 			DrawElementsInstancedBaseVertex,
 			Error,
 			EnumParam(primitive)
@@ -746,7 +746,7 @@ public:
 			inst_count,
 			base_vertex
 		);
-		OGLPLUS_CHECK(
+		OGLPLUS_VERIFY(
 			DrawElementsInstancedBaseVertex,
 			Error,
 			EnumParam(primitive)
@@ -777,7 +777,7 @@ public:
 			draw_count,
 			const_cast<GLint*>(base_vertex) //TODO remove const_cast
 		);
-		OGLPLUS_CHECK(
+		OGLPLUS_VERIFY(
 			MultiDrawElementsBaseVertex,
 			Error,
 			EnumParam(primitive)
@@ -810,7 +810,7 @@ public:
 			draw_count,
 			const_cast<GLint*>(base_vertex) //TODO remove const_cast
 		);
-		OGLPLUS_CHECK(
+		OGLPLUS_VERIFY(
 			MultiDrawElementsBaseVertex,
 			Error,
 			EnumParam(primitive)
@@ -845,7 +845,7 @@ public:
 			base_vertex,
 			base_instance
 		);
-		OGLPLUS_CHECK(
+		OGLPLUS_VERIFY(
 			DrawElementsInstancedBaseVertexBaseInstance,
 			Error,
 			EnumParam(primitive)
@@ -880,7 +880,7 @@ public:
 			base_vertex,
 			base_instance
 		);
-		OGLPLUS_CHECK(
+		OGLPLUS_VERIFY(
 			DrawElementsInstancedBaseVertexBaseInstance,
 			Error,
 			EnumParam(primitive)
@@ -898,7 +898,7 @@ public:
 			GLenum(primitive),
 			GetGLName(xfb)
 		);
-		OGLPLUS_CHECK(
+		OGLPLUS_VERIFY(
 			DrawTransformFeedback,
 			ObjectError,
 			Object(xfb).


### PR DESCRIPTION
I noticed that every draw call is followed by a glGetError even in LOW_PROFILE mode. My expectation would be that draw calls rarely fail in a way that would not be caught during development, but that the checks cause unnecessary overhead in release (e.g. driver thread synchronization). Therefore I propose to disable the checks in LOW_PROFILE mode, i.e. change OGLPLUS_CHECK to OGLPLUS_VERIFY. Thanks!
