### PR TITLE
Resolve warnings for MSVC Treat Warnings As Errors.

### DIFF
--- a/implement/oglplus/detail/glsl_source.ipp
+++ b/implement/oglplus/detail/glsl_source.ipp
@@ -27,7 +27,7 @@ StrCRefsGLSLSrcWrap::StrCRefsGLSLSrcWrap(
 		assert(pptr != _ptrs.end());
 		assert(psize != _sizes.end());
 		*pptr = i->begin();
-		*psize = i->size();
+		*psize = static_cast<int>(i->size());
 		++i;
 		++pptr;
 		++psize;
@@ -124,7 +124,7 @@ OGLPLUS_LIB_FUNC
 InputStreamGLSLSrcWrap::InputStreamGLSLSrcWrap(std::istream& input)
  : _storage(_read_data(input, _check_and_get_size(input)))
  , _pdata(_storage.data())
- , _size(_storage.size())
+ , _size(static_cast<GLint>(_storage.size()))
 { }
 
 OGLPLUS_LIB_FUNC

--- a/implement/oglplus/detail/info_log.ipp
+++ b/implement/oglplus/detail/info_log.ipp
@@ -39,7 +39,7 @@ String GetInfoLog(
 		std::vector<GLchar> buffer(length);
 		GetObjectInfoLog(
 			object_name,
-			buffer.size(),
+			static_cast<GLsizei>(buffer.size()),
 			&real_length,
 			buffer.data()
 		);

--- a/implement/oglplus/detail/program.ipp
+++ b/implement/oglplus/detail/program.ipp
@@ -44,7 +44,7 @@ ActiveVariableInfo::ActiveVariableInfo(
 	GetActiveVariable(
 		GetGLName(context.Program()),
 		index,
-		context.Buffer().size(),
+		static_cast<GLsizei>(context.Buffer().size()),
 		&strlen,
 		&_size,
 		&_type,
@@ -102,7 +102,7 @@ ActiveSubroutineInfo::ActiveSubroutineInfo(
 		GetGLName(context.Program()),
 		context.Stage(),
 		index,
-		context.Buffer().size(),
+		static_cast<GLsizei>(context.Buffer().size()),
 		&strlen,
 		context.Buffer().data()
 	);
@@ -156,7 +156,7 @@ ActiveSubroutineUniformInfo::ActiveSubroutineUniformInfo(
 		GetGLName(context.Program()),
 		context.Stage(),
 		index,
-		context.Buffer().size(),
+		static_cast<GLsizei>(context.Buffer().size()),
 		&strlen,
 		context.Buffer().data()
 	);
@@ -229,7 +229,7 @@ ActiveUniformBlockInfo::ActiveUniformBlockInfo(
 	OGLPLUS_GLFUNC(GetActiveUniformBlockName)(
 		GetGLName(context.Program()),
 		index,
-		context.Buffer().size(),
+		static_cast<GLsizei>(context.Buffer().size()),
 		&strlen,
 		context.Buffer().data()
 	);

--- a/implement/oglplus/program.ipp
+++ b/implement/oglplus/program.ipp
@@ -301,7 +301,7 @@ Binary(const std::vector<GLubyte>& binary, GLenum format)
 		_name,
 		format,
 		binary.data(),
-		binary.size()
+		static_cast<GLsizei>(binary.size())
 	);
 	OGLPLUS_CHECK(
 		ProgramBinary,
@@ -320,7 +320,7 @@ ShaderIterationContext::ShaderIterationContext(
 {
 	OGLPLUS_GLFUNC(GetAttachedShaders)(
 		name,
-		_shader_names.size(),
+		static_cast<GLsizei>(_shader_names.size()),
 		nullptr,
 		_shader_names.data()
 	);

--- a/implement/oglplus/program_resource.ipp
+++ b/implement/oglplus/program_resource.ipp
@@ -51,7 +51,7 @@ ProgramResource::ProgramResource(
  , _interface(context.Interface())
  , _index(index)
 {
-	GLsizei bufsize = context.Buffer().size();
+	GLsizei bufsize = static_cast<GLsizei>(context.Buffer().size());
 	if(bufsize != 0)
 	{
 		GLsizei length = 0;

--- a/implement/oglplus/texture.ipp
+++ b/implement/oglplus/texture.ipp
@@ -204,7 +204,7 @@ GetImage(
 		level,
 		GLenum(format),
 		GLenum(dest.Type()),
-		dest.Size(),
+		static_cast<GLsizei>(dest.Size()),
 		dest.Addr()
 	);
 	OGLPLUS_CHECK(
@@ -245,7 +245,7 @@ GetCompressedImage(
 	OGLPLUS_GLFUNC(GetnCompressedTexImageARB)(
 		GLenum(target),
 		level,
-		dest.Size(),
+		static_cast<GLsizei>(dest.Size()),
 		dest.Addr()
 	);
 	OGLPLUS_CHECK(

--- a/implement/oglplus/uniform.ipp
+++ b/implement/oglplus/uniform.ipp
@@ -64,7 +64,7 @@ GetType(ProgramName program, GLint /*location*/, StrCRef identifier)
 		OGLPLUS_GLFUNC(GetActiveUniform)(
 			GetGLName(program),
 			index,
-			buffer.size(),
+			static_cast<GLsizei>(buffer.size()),
 			&length,
 			&size,
 			&type,

--- a/include/oglplus/context/buffer_selection.hpp
+++ b/include/oglplus/context/buffer_selection.hpp
@@ -56,7 +56,7 @@ public:
 	static void DrawBuffers(const EnumArray<ColorBuffer>& buffers)
 	{
 		OGLPLUS_GLFUNC(DrawBuffers)(
-			buffers.Count(),
+			static_cast<GLsizei>(buffers.Count()),
 			buffers.Values()
 		);
 		OGLPLUS_VERIFY_SIMPLE(DrawBuffers);

--- a/include/oglplus/context/viewport.hpp
+++ b/include/oglplus/context/viewport.hpp
@@ -384,10 +384,10 @@ public:
 	{
 		OGLPLUS_GLFUNC(ViewportIndexedf)(
 			viewport,
-			vp.X(),
-			vp.Y(),
-			vp.Width(),
-			vp.Height()
+			static_cast<GLfloat>(vp.X()),
+			static_cast<GLfloat>(vp.Y()),
+			static_cast<GLfloat>(vp.Width()),
+			static_cast<GLfloat>(vp.Height())
 		);
 		OGLPLUS_CHECK(
 			ViewportIndexedf,

--- a/include/oglplus/error/limit.hpp
+++ b/include/oglplus/error/limit.hpp
@@ -48,6 +48,12 @@ public:
 		return *this;
 	}
 
+	LimitError& Value(GLuint value)
+	{
+		_value = static_cast<GLfloat>( value );
+		return *this;
+	}
+
 	/// The value assigned to the limited-type variable
 	GLfloat Value(void) const { return _value; }
 
@@ -57,6 +63,11 @@ public:
 		return *this;
 	}
 
+	LimitError& Limit(GLuint limit)
+	{
+		_limit = static_cast<GLfloat>( limit );
+		return *this;
+	}
 	/// The allowed limit of the limited-type
 	GLfloat Limit(void) const { return _limit; }
 };

--- a/include/oglplus/framebuffer.hpp
+++ b/include/oglplus/framebuffer.hpp
@@ -534,7 +534,7 @@ public:
 	{
 		OGLPLUS_GLFUNC(InvalidateFramebuffer)(
 			GLenum(target),
-			buffers.Count(),
+			static_cast<GLsizei>( buffers.Count()),
 			buffers.Values()
 		);
 		OGLPLUS_CHECK(
@@ -579,7 +579,7 @@ public:
 	{
 		OGLPLUS_GLFUNC(InvalidateSubFramebuffer)(
 			GLenum(target),
-			buffers.Count(),
+			static_cast<GLsizei>(buffers.Count()),
 			buffers.Values(),
 			x,
 			y,

--- a/include/oglplus/program.hpp
+++ b/include/oglplus/program.hpp
@@ -948,7 +948,7 @@ public:
 		if(!names.empty())
 		{
 			prog.TransformFeedbackVaryings(
-				names.size(),
+				static_cast<GLsizei>(names.size()),
 				names.data(),
 				mode
 			);


### PR DESCRIPTION
Explicitly casting input to specific GL functions that were throwing
warnings.
Can now build on MSVC with Treat Warnings As Errors ( /WX ).