### PR TITLE
#103: move operations seem to sometimes trigger deletion of the underlying object

### DIFF
--- a/include/oglplus/object/wrap_tpl.hpp
+++ b/include/oglplus/object/wrap_tpl.hpp
@@ -149,7 +149,7 @@ private:
 
 	void _cleanup(void)
 	{
-		if(this->_obj_name() > 0u)
+		if(this->_obj_name() != _invalid_name())
 		{
 			_undescribe();
 			ObjGenDelOps<ObjTag>::Delete(1, this->_name_ptr());


### PR DESCRIPTION
per #103 the new `_invalid_name()` method returns the ones-complement of zero, which for a GLuint is not a negative number.  Hence the comparison always succeeds.  I'm not clear why _name_ptr() is still returning the value for the object prior to when it was set to `_invalid_name()` though.  