### PR TITLE
Added libpng allocation checks and warning support.

### DIFF
--- a/implement/oglplus/images/png.ipp
+++ b/implement/oglplus/images/png.ipp
@@ -12,6 +12,7 @@
 #include <stdexcept>
 #include <fstream>
 #include <cassert>
+#include <iostream>
 #include <png.h>
 
 namespace oglplus {
@@ -131,9 +132,10 @@ void PNGReadStruct::_png_handle_error(
 OGLPLUS_LIB_FUNC
 void PNGReadStruct::_png_handle_warning(
 	::png_structp /*sp*/,
-	const char* /*msg*/
+	const char* msg
 )
 {
+	::std::cerr << "libpng warning: " << msg << ::std::endl;
 }
 
 OGLPLUS_LIB_FUNC
@@ -144,7 +146,9 @@ PNGReadStruct::PNGReadStruct(PNGLoader& /*loader*/)
 	&_png_handle_error,
 	&_png_handle_warning
 ))
-{ }
+{
+	assert(_read);
+}
 
 OGLPLUS_LIB_FUNC
 PNGReadStruct::~PNGReadStruct(void)
@@ -160,7 +164,9 @@ OGLPLUS_LIB_FUNC
 PNGReadInfoStruct::PNGReadInfoStruct(PNGLoader& loader)
  : PNGReadStruct(loader)
  , _info(::png_create_info_struct(_read))
-{ }
+{
+	assert(_info);
+}
 
 OGLPLUS_LIB_FUNC
 PNGReadInfoStruct::~PNGReadInfoStruct(void)
@@ -200,6 +206,7 @@ PNGReadInfoEndStruct::PNGReadInfoEndStruct(PNGLoader& loader)
  : PNGReadInfoStruct(loader)
  , _end(::png_create_info_struct(_read))
 {
+	assert(_end);
 	::png_set_read_fn(
 		_read,
 		reinterpret_cast<::png_voidp>(&loader),


### PR DESCRIPTION
I was debugging a problem with PNG loading, which led me to these changes. I believe those could be useful for others in the future. I added:

1. Return value checks for libpng allocation functions (as suggested by documentation).
2. Actually printing libpng warnings to stderr. Now, I noticed that oglplus, as-of-yet, doesn't print anything to standard outputs, and I understand this may feel ugly. If you have a better idea for handling those warnings (only in debug build perhaps?) I'm all for it, but I believe they should not be silenced, as they can be extremely useful (mine was "Application built with libpng-1.4.12 but running with 1.6.18").