### PR TITLE
Fix ProgVar ParamType alignment not compiling on MSVC

### DIFF
--- a/include/oglplus/prog_var/type_ops.hpp
+++ b/include/oglplus/prog_var/type_ops.hpp
@@ -30,7 +30,7 @@ struct AdjustProgVar
 	typedef T BaseType;
 	typedef T ValueType;
 
-	inline static BaseType Adjust(ValueType value)
+	inline static BaseType Adjust(const ValueType &value)
 	{
 		return value;
 	}

--- a/include/oglplus/prog_var/wrapper.hpp
+++ b/include/oglplus/prog_var/wrapper.hpp
@@ -121,7 +121,7 @@ public:
 	typedef typename AdjustProgVar<T>::ValueType ParamType;
 
 	/// Set the variable value
-	void Set(ParamType value)
+	void Set(const ParamType &value)
 	{
 		BaseGetSetOps::RequireActive();
 		BaseGetSetOps::SetValue(AdjustProgVar<T>::Adjust(value));
@@ -164,7 +164,7 @@ public:
 	}
 
 	/// Sets the variable value if it is active
-	void TrySet(ParamType value)
+	void TrySet(const ParamType &value)
 	{
 		if(this->IsActive())
 		{
@@ -173,7 +173,7 @@ public:
 	}
 
 	/// Sets the variable value
-	ProgVar& operator = (ParamType value)
+	ProgVar& operator = (const ParamType &value)
 	{
 		this->Set(value);
 		return *this;


### PR DESCRIPTION
Getting some of these errors compiling a project using Visual Studio Community 2015:

```
1>C:\Users\vagrant\swarms\external\include\oglplus/prog_var/type_ops.hpp(34): error C2719: 'value': formal parameter with requested alignment of 16 won't be aligned
1>C:\Users\vagrant\swarms\external\include\oglplus/prog_var/wrapper.hpp(125): error C2719: 'value': formal parameter with requested alignment of 16 won't be aligned
1>C:\Users\vagrant\swarms\external\include\oglplus/prog_var/wrapper.hpp(168): error C2719: 'value': formal parameter with requested alignment of 16 won't be aligned
1>C:\Users\vagrant\swarms\external\include\oglplus/prog_var/wrapper.hpp(177): error C2719: 'value': formal parameter with requested alignment of 16 won't be aligned
```

This is using the default __cdecl calling convention and building a 32-bit executable. Changing the type to const references fixes the problem, but I'm not sure this is the correct solution.