### PR TITLE
Call glCreateBuffers for DSA buffers

### DIFF
--- a/include/oglplus/buffer.hpp
+++ b/include/oglplus/buffer.hpp
@@ -56,8 +56,8 @@ protected:
 	static void Gen(tag::Create, GLsizei count, GLuint* names)
 	{
 		assert(names != nullptr);
-		OGLPLUS_GLFUNC(GenBuffers)(count, names);
-		OGLPLUS_CHECK_SIMPLE(GenBuffers);
+		OGLPLUS_GLFUNC(CreateBuffers)(count, names);
+		OGLPLUS_CHECK_SIMPLE(CreateBuffers);
 	}
 #endif
 


### PR DESCRIPTION
I'm a bit confused about how this ever worked for anyone. DSA operations should be called after glCreateBuffers rather than glGenBuffers.