### PR TITLE
Use public _obj_name() instead of private _name

### DIFF
--- a/implement/oglplus/dsa/buffer.ipp
+++ b/implement/oglplus/dsa/buffer.ipp
@@ -18,14 +18,14 @@ GetIntParam(GLenum query) const
 {
 	GLint value = 0;
 	OGLPLUS_GLFUNC(GetNamedBufferParameteriv)(
-		_name,
+		_obj_name(),
 		query,
 		&value
 	);
 	OGLPLUS_VERIFY(
 		GetNamedBufferParameteriv,
 		ObjectError,
-		Object(BufferName(_name)).
+		Object(BufferName(_obj_name())).
 		EnumParam(query)
 	);
 	return value;


### PR DESCRIPTION
`_name` is inaccessible in this scope according to MSVC.