### PR TITLE
Fix missing return in SettingStackIndexed.Push(...)

### DIFF
--- a/include/oglplus/client/setting.hpp
+++ b/include/oglplus/client/setting.hpp
@@ -225,7 +225,7 @@ public:
 		return Indexed(index);
 	}
 
-	typedef SettingHolder<T, GLuint> Holder;
+	typedef SettingHolder<T, Index> Holder;
 
 	inline
 	Holder Push(T value)
@@ -237,7 +237,7 @@ public:
 	inline
 	Holder Push(A&& ... a)
 	{
-		_zero().Push(std::forward<A>(a)...);
+		return _zero().Push(std::forward<A>(a)...);
 	}
 
 	inline


### PR DESCRIPTION
This was causing a crash whenever I tried to do something like:

```c++
oglplus::ClientContext gl;
auto viewport = gl.Viewport.Push(0, 0, w, h);
auto scissor = gl.Scissor.Push(0, 0, w, h);
```