### PR TITLE
Fixed compatibility with GLM versions >= 0.9.9

### DIFF
--- a/include/oglplus/interop/glm.hpp
+++ b/include/oglplus/interop/glm.hpp
@@ -44,8 +44,18 @@ namespace oglplus {
 #define OGLPLUS_GLM_TPLNS ::glm::detail
 #endif
 
+#if	(GLM_VERSION_MAJOR > 0) || ( \
+	(GLM_VERSION_MINOR > 9) || ( \
+		(GLM_VERSION_MINOR == 9) && \
+		(GLM_VERSION_PATCH > 8) \
+	))
+#define OGLPLUS_GLM_PRECISION_TYPE qualifier
+#else
+#define OGLPLUS_GLM_PRECISION_TYPE precision
+#endif
+
 #define OGLPLUS_IMPL_GLM_VEC_UNIFORM_OPS(DIM) \
-template <typename OpsTag, typename T, glm::precision P> \
+template <typename OpsTag, typename T, glm::OGLPLUS_GLM_PRECISION_TYPE P> \
 class ProgVarGetSetOps<OpsTag, tag::Uniform, OGLPLUS_GLM_TPLNS::tvec##DIM<T, P>> \
  : public ProgVarCommonOps<tag::Uniform> \
  , public ProgVarBaseSetOps<OpsTag, tag::Uniform, tag::NativeTypes, T, 4> \
@@ -64,7 +74,7 @@ public: \
 		); \
 	} \
 }; \
-template <typename T, glm::precision P> \
+template <typename T, glm::OGLPLUS_GLM_PRECISION_TYPE P> \
 struct GLSLtoCppTypeMatcher<OGLPLUS_GLM_TPLNS::tvec##DIM<T, P>> \
  : GLSLtoCppTypeMatcher<oglplus::Vector<T, DIM> > { }; \
 
@@ -75,7 +85,7 @@ OGLPLUS_IMPL_GLM_VEC_UNIFORM_OPS(4)
 #undef OGLPLUS_IMPL_GLM_VEC_UNIFORM_OPS
 
 #define OGLPLUS_IMPL_GLM_MAT_UNIFORM_OPS(R, C) \
-template <typename OpsTag, typename T, glm::precision P> \
+template <typename OpsTag, typename T, glm::OGLPLUS_GLM_PRECISION_TYPE P> \
 class ProgVarGetSetOps<OpsTag, tag::Uniform, OGLPLUS_GLM_TPLNS::tmat##C##x##R<T, P>> \
  : public ProgVarCommonOps<tag::Uniform> \
  , public ProgVarBaseSetOps<OpsTag, tag::Uniform, tag::MatrixTypes, T, 16> \
@@ -96,7 +106,7 @@ public: \
 		); \
 	} \
 }; \
-template <typename T, glm::precision P> \
+template <typename T, glm::OGLPLUS_GLM_PRECISION_TYPE P> \
 struct GLSLtoCppTypeMatcher<OGLPLUS_GLM_TPLNS::tmat##C##x##R<T, P>> \
  : GLSLtoCppTypeMatcher<oglplus::Matrix<T, R, C> > { }; \
 


### PR DESCRIPTION
Fixes the following error when using GLM >= 0.9.9 with oglplus:
> /usr/local/include/oglplus/interop/glm.hpp:71:1: error: ‘glm::precision’ has not been declared

- https://github.com/g-truc/glm/commit/a7b72ec renamed glm::precision to glm::qualifier
- https://github.com/matus-chochlik/oglplus/blob/b2279685333a9eec588b64bf4bc983be8854b05a/include/oglplus/interop/glm.hpp fails to compile with glm versions including and after this commit
- this PR conditionally uses the new glm::qualifier for versions >= 0.9.9
- tested with https://launchpad.net/ubuntu/+source/glm/0.9.7.2-1
  - worked previously and still works
- tested with https://launchpad.net/ubuntu/+source/glm/0.9.9~a2-2
  - did not work previously and works now